### PR TITLE
Encrypt the last layer of the created images

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -69,18 +69,18 @@ jobs:
       - name: Encrypt final layer and push image
         run: |
           set -euxo pipefail
-          export GNUPGHOME="$(mktemp -d)"
-          echo "${{ secrets.GPG_KEY }}" | base64 --decode | gpg --batch --yes --import
+          keyfile=$(mktemp)
+          echo "${{ secrets.JWE_KEY }}" > ${keyfile}
           for tag in ${{ steps.meta.outputs.tags }}
           do
             echo "Encrypting last layer of ${tag}"
             podman push \
               --creds "${{ github.actor }}:${{ github.token }}" \
               --encrypt-layer -1 \
-              --encryption-key pgp:fedora_apps \
+              --encryption-key jwe:${keyfile} \
               "${tag}"
           done
-          rm -rf "$GNUPGHOME"
+          rm -f ${keyfile}
 
   combine-tags:
     strategy:

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -69,12 +69,19 @@ jobs:
       - name: Encrypt final layer
         run: |
           echo ${{ secrets.GPG_KEY }} | base64 -d | gpg --import
-          for tag in ${{ steps.meta.outputs.tags }}
-          do
-            echo "Encrypting last layer of ${tag}"
-            buildah commit --encrypt-layer -1 --encryption-key pgp:fedora_apps ${tag}
-          done
-
+run: |
+  set -euxo pipefail
+  export GNUPGHOME="$(mktemp -d)"
+  echo "${{ secrets.GPG_KEY }}" | base64 --decode | gpg --batch --yes --import
+  for tag in ${{ steps.meta.outputs.tags }}
+  do
+    echo "Encrypting last layer of ${tag}"
+    buildah commit --encrypt-layer -1 \
+      --encryption-key pgp:fedora_apps \
+      "${{ steps.build-image.outputs.image }}" \
+      "${tag}"
+  done
+  rm -rf "$GNUPGHOME"
       - name: Push image
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -66,21 +66,30 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Encrypt final layer and push image
+      - name: Write keyfile
         run: |
           set -euxo pipefail
           keyfile=$(mktemp)
           echo "${{ secrets.JWE_KEY }}" > ${keyfile}
-          for tag in ${{ steps.meta.outputs.tags }}
-          do
-            echo "Encrypting last layer of ${tag}"
-            podman push \
-              --creds "${{ github.actor }}:${{ github.token }}" \
-              --encrypt-layer -1 \
-              --encryption-key jwe:${keyfile} \
-              "${tag}"
-          done
+          echo "keyfile=${keyfile}" >> $GITHUB_ENV
+
+      - name: Encrypt final layer and push image
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+          extra-args: |
+            --encrypt-layer -1
+            --encryption-key jwe:${keyfile}
+
+      - name: Delete keyfile
+        run: |
+          set -euxo pipefail
           rm -f ${keyfile}
+
+          
 
   combine-tags:
     strategy:
@@ -108,19 +117,6 @@ jobs:
             type=semver,pattern=v{{version}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
-
-      #- name: Pull image
-      #  run: |
-      #    keyfile=$(mktemp)
-      #    echo "${{ secrets.JWE_KEY }}" > ${keyfile}
-      #    for tag in ${{ steps.meta.outputs.tags }}
-      #    do
-      #      echo "Pulling ${tag}-amd64"
-      #      podman pull --decryption-key jwe:${keyfile} ${tag}-amd64
-      #      echo "Pulling ${tag}-arm64"
-      #      podman pull --decryption-key jwe:${keyfile} ${tag}-arm64
-      #    done
-      #    rm -f ${keyfile}
 
       - name: Generate manifest
         run: |

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -82,7 +82,7 @@ jobs:
           password: ${{ github.token }}
           extra-args: |
             --encrypt-layer -1
-            --encryption-key jwe:${keyfile}
+            --encryption-key jwe:${{ env.keyfile }}
 
       - name: Delete keyfile
         run: |

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -66,7 +66,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Encrypt final layer
+      - name: Encrypt final layer and push image
         run: |
           set -euxo pipefail
           export GNUPGHOME="$(mktemp -d)"
@@ -74,20 +74,13 @@ jobs:
           for tag in ${{ steps.meta.outputs.tags }}
           do
             echo "Encrypting last layer of ${tag}"
-            buildah commit --encrypt-layer -1 \
+            buildah push \
+              --creds "${{ github.actor }}:${{ github.token }}"
+              --encrypt-layer -1 \
               --encryption-key pgp:fedora_apps \
-              "${{ steps.build-image.outputs.image }}" \
               "${tag}"
           done
           rm -rf "$GNUPGHOME"
-
-      - name: Push image
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
 
   combine-tags:
     strategy:

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -66,6 +66,15 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Encrypt final layer
+        run: |
+          echo ${{ secrets.GPG_KEY }} | base64 -d | gpg --import
+          for tag in ${{ steps.meta.outputs.tags }}
+          do
+            echo "Encrypting last layer of ${tag}"
+            buildah commit --encrypt-layer -1 --encryption-key pgp:fedora_apps ${tag}
+          done
+
       - name: Push image
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -68,20 +68,19 @@ jobs:
 
       - name: Encrypt final layer
         run: |
-          echo ${{ secrets.GPG_KEY }} | base64 -d | gpg --import
-run: |
-  set -euxo pipefail
-  export GNUPGHOME="$(mktemp -d)"
-  echo "${{ secrets.GPG_KEY }}" | base64 --decode | gpg --batch --yes --import
-  for tag in ${{ steps.meta.outputs.tags }}
-  do
-    echo "Encrypting last layer of ${tag}"
-    buildah commit --encrypt-layer -1 \
-      --encryption-key pgp:fedora_apps \
-      "${{ steps.build-image.outputs.image }}" \
-      "${tag}"
-  done
-  rm -rf "$GNUPGHOME"
+          set -euxo pipefail
+          export GNUPGHOME="$(mktemp -d)"
+          echo "${{ secrets.GPG_KEY }}" | base64 --decode | gpg --batch --yes --import
+          for tag in ${{ steps.meta.outputs.tags }}
+          do
+            echo "Encrypting last layer of ${tag}"
+            buildah commit --encrypt-layer -1 \
+              --encryption-key pgp:fedora_apps \
+              "${{ steps.build-image.outputs.image }}" \
+              "${tag}"
+          done
+          rm -rf "$GNUPGHOME"
+
       - name: Push image
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -109,15 +109,18 @@ jobs:
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
 
-      - name: Pull image
-        run: |
-          for tag in ${{ steps.meta.outputs.tags }}
-          do
-            echo "Pulling ${tag}-amd64"
-            podman pull ${tag}-amd64
-            echo "Pulling ${tag}-arm64"
-            podman pull ${tag}-arm64
-          done
+      #- name: Pull image
+      #  run: |
+      #    keyfile=$(mktemp)
+      #    echo "${{ secrets.JWE_KEY }}" > ${keyfile}
+      #    for tag in ${{ steps.meta.outputs.tags }}
+      #    do
+      #      echo "Pulling ${tag}-amd64"
+      #      podman pull --decryption-key jwe:${keyfile} ${tag}-amd64
+      #      echo "Pulling ${tag}-arm64"
+      #      podman pull --decryption-key jwe:${keyfile} ${tag}-arm64
+      #    done
+      #    rm -f ${keyfile}
 
       - name: Generate manifest
         run: |

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -69,9 +69,9 @@ jobs:
       - name: Write keyfile
         run: |
           set -euxo pipefail
-          keyfile=$(mktemp)
-          echo "${{ secrets.JWE_KEY }}" > ${keyfile}
-          echo "keyfile=${keyfile}" >> $GITHUB_ENV
+          keyfile="$(mktemp)"
+          echo "${{ secrets.JWE_KEY }}" > "${keyfile}"
+          echo "keyfile=${keyfile}" >> "$GITHUB_ENV"
 
       - name: Encrypt final layer and push image
         uses: redhat-actions/push-to-registry@v2
@@ -87,9 +87,7 @@ jobs:
       - name: Delete keyfile
         run: |
           set -euxo pipefail
-          rm -f ${keyfile}
-
-          
+          rm -f "${{ env.keyfile }}"
 
   combine-tags:
     strategy:

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -74,7 +74,7 @@ jobs:
           for tag in ${{ steps.meta.outputs.tags }}
           do
             echo "Encrypting last layer of ${tag}"
-            buildah push \
+            podman push \
               --creds "${{ github.actor }}:${{ github.token }}" \
               --encrypt-layer -1 \
               --encryption-key pgp:fedora_apps \

--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -75,7 +75,7 @@ jobs:
           do
             echo "Encrypting last layer of ${tag}"
             buildah push \
-              --creds "${{ github.actor }}:${{ github.token }}"
+              --creds "${{ github.actor }}:${{ github.token }}" \
               --encrypt-layer -1 \
               --encryption-key pgp:fedora_apps \
               "${tag}"


### PR DESCRIPTION
The last layer will contain configurations. In order to prevent them from being public while the images are still public, the last layer should be encrypted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added an encryption step to secure the final layer of container images before they are pushed to the registry.  
  - Removed the step that pulled platform-specific images during the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->