### PR TITLE
Specify version number for base container

### DIFF
--- a/chrony/Containerfile
+++ b/chrony/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/dockurr/chrony:latest
+FROM docker.io/dockurr/chrony:4.7
 
 ADD rootfs/ /
 


### PR DESCRIPTION
Dependabot will identify out of date container references so there is no need to use latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the base image in the container configuration to use a specific version for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->