### PR TITLE
Add a read and write timeout to kea

### DIFF
--- a/kea/Containerfile
+++ b/kea/Containerfile
@@ -5,5 +5,7 @@ RUN apk add --no-cache \
 
 COPY rootfs /
 
+RUN /usr/sbin/kea-dhcp4 -t /etc/kea/kea-dhcp4.conf
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/usr/sbin/kea-dhcp4", "-c", "/etc/kea/kea-dhcp4.conf"]

--- a/kea/ansible/templates/kea-dhcp4.conf.j2
+++ b/kea/ansible/templates/kea-dhcp4.conf.j2
@@ -27,6 +27,8 @@
     "lease-database": {
       "type":                "postgresql",
       "max-reconnect-tries": 0,
+      "read-timeout":        10,
+      "write-timeout":       20,
       "on-fail":             "serve-retry-exit",
       "name":                "{{ postgresql.database }}",
       "user":                "{{ postgresql.username }}",


### PR DESCRIPTION
Some requests seem to fail. Possibly from an infinite timeout mixed with a hiccup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic configuration validation for the Kea DHCP4 server during container image build.

* **Enhancements**
  * Updated Kea DHCPv4 configuration to include database read and write timeout settings for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->